### PR TITLE
Add history with refactoring

### DIFF
--- a/cmd/event-collector/main.go
+++ b/cmd/event-collector/main.go
@@ -37,7 +37,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err, repo := repository.NewECRepo(ctx, &ecConfig)
+	repo, err := repository.NewECRepo(ctx, &ecConfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not create db repository: %v\n", err)
 		os.Exit(1)

--- a/internal/repository/application.go
+++ b/internal/repository/application.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func (s *RepoPostgres) UpsertApplications(apps []*dao.ApplicationDAOInfo) error {
+func (s *RepoPostgres) UpsertApplications(ctx context.Context, apps []*dao.ApplicationDAOInfo) error {
 	upsertApp := `INSERT INTO applications (id, app_id, used_resource, max_used_resource, pending_resource,
 			partition, queue_name, submission_time, finished_time, requests, allocations, state,
 			"user", groups, rejected_message, state_log, place_holder_data, has_reserved, reservations,
@@ -33,7 +33,7 @@ func (s *RepoPostgres) UpsertApplications(apps []*dao.ApplicationDAOInfo) error 
 			max_request_priority = EXCLUDED.max_request_priority`
 
 	for _, a := range apps {
-		_, err := s.dbpool.Exec(context.Background(), upsertApp,
+		_, err := s.dbpool.Exec(ctx, upsertApp,
 			pgx.NamedArgs{
 				"id":                   uuid.NewString(),
 				"app_id":               a.ApplicationID,
@@ -63,12 +63,12 @@ func (s *RepoPostgres) UpsertApplications(apps []*dao.ApplicationDAOInfo) error 
 	return nil
 }
 
-func (s *RepoPostgres) GetAllApplications() ([]*dao.ApplicationDAOInfo, error) {
+func (s *RepoPostgres) GetAllApplications(ctx context.Context) ([]*dao.ApplicationDAOInfo, error) {
 	selectStmt := `SELECT * FROM applications`
 
 	var apps []*dao.ApplicationDAOInfo
 
-	rows, err := s.dbpool.Query(context.Background(), selectStmt)
+	rows, err := s.dbpool.Query(ctx, selectStmt)
 	if err != nil {
 		return nil, fmt.Errorf("could not get applications from DB: %v", err)
 	}
@@ -88,12 +88,12 @@ func (s *RepoPostgres) GetAllApplications() ([]*dao.ApplicationDAOInfo, error) {
 	return apps, nil
 }
 
-func (s *RepoPostgres) GetAppsPerPartitionPerQueue(partition, queue string) ([]*dao.ApplicationDAOInfo, error) {
+func (s *RepoPostgres) GetAppsPerPartitionPerQueue(ctx context.Context, partition, queue string) ([]*dao.ApplicationDAOInfo, error) {
 	selectStmt := `SELECT * FROM applications WHERE queue_name = $1 AND partition = $2`
 
 	var apps []*dao.ApplicationDAOInfo
 
-	rows, err := s.dbpool.Query(context.Background(), selectStmt, queue, partition)
+	rows, err := s.dbpool.Query(ctx, selectStmt, queue, partition)
 	if err != nil {
 		return nil, fmt.Errorf("could not get applications from DB: %v", err)
 	}

--- a/internal/repository/application.go
+++ b/internal/repository/application.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *RepoPostgres) UpsertApplications(ctx context.Context, apps []*dao.ApplicationDAOInfo) error {
-	upsertApp := `INSERT INTO applications (id, app_id, used_resource, max_used_resource, pending_resource,
+	upsertSQL := `INSERT INTO applications (id, app_id, used_resource, max_used_resource, pending_resource,
 			partition, queue_name, submission_time, finished_time, requests, allocations, state,
 			"user", groups, rejected_message, state_log, place_holder_data, has_reserved, reservations,
 			max_request_priority)
@@ -33,7 +33,7 @@ func (s *RepoPostgres) UpsertApplications(ctx context.Context, apps []*dao.Appli
 			max_request_priority = EXCLUDED.max_request_priority`
 
 	for _, a := range apps {
-		_, err := s.dbpool.Exec(ctx, upsertApp,
+		_, err := s.dbpool.Exec(ctx, upsertSQL,
 			pgx.NamedArgs{
 				"id":                   uuid.NewString(),
 				"app_id":               a.ApplicationID,
@@ -64,11 +64,11 @@ func (s *RepoPostgres) UpsertApplications(ctx context.Context, apps []*dao.Appli
 }
 
 func (s *RepoPostgres) GetAllApplications(ctx context.Context) ([]*dao.ApplicationDAOInfo, error) {
-	selectStmt := `SELECT * FROM applications`
+	selectSQL := `SELECT * FROM applications`
 
 	var apps []*dao.ApplicationDAOInfo
 
-	rows, err := s.dbpool.Query(ctx, selectStmt)
+	rows, err := s.dbpool.Query(ctx, selectSQL)
 	if err != nil {
 		return nil, fmt.Errorf("could not get applications from DB: %v", err)
 	}
@@ -89,11 +89,11 @@ func (s *RepoPostgres) GetAllApplications(ctx context.Context) ([]*dao.Applicati
 }
 
 func (s *RepoPostgres) GetAppsPerPartitionPerQueue(ctx context.Context, partition, queue string) ([]*dao.ApplicationDAOInfo, error) {
-	selectStmt := `SELECT * FROM applications WHERE queue_name = $1 AND partition = $2`
+	selectSQL := `SELECT * FROM applications WHERE queue_name = $1 AND partition = $2`
 
 	var apps []*dao.ApplicationDAOInfo
 
-	rows, err := s.dbpool.Query(ctx, selectStmt, queue, partition)
+	rows, err := s.dbpool.Query(ctx, selectSQL, queue, partition)
 	if err != nil {
 		return nil, fmt.Errorf("could not get applications from DB: %v", err)
 	}

--- a/internal/repository/history.go
+++ b/internal/repository/history.go
@@ -1,0 +1,81 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/yunikorn-core/pkg/webservice/dao"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+func (s *RepoPostgres) UpdateHistory(ctx context.Context, apps []*dao.ApplicationHistoryDAOInfo, containers []*dao.ContainerHistoryDAOInfo) error {
+	app_upsertStmt := `INSERT INTO history (id, history_type, total_number, timestamp) VALUES (@id, 'application', @total_number, @timestamp)`
+	container_upsertStmt := `INSERT INTO history (id, history_type, total_number, timestamp) VALUES (@id, 'container', @total_number, @timestamp)`
+
+	for _, app := range apps {
+		_, err := s.dbpool.Exec(ctx, app_upsertStmt,
+			pgx.NamedArgs{
+				"id":           uuid.NewString(),
+				"total_number": app.TotalApplications,
+				"timestamp":    app.Timestamp,
+			})
+		if err != nil {
+			return fmt.Errorf("could not update applications history into DB: %v", err)
+		}
+	}
+	for _, container := range containers {
+		_, err := s.dbpool.Exec(ctx, container_upsertStmt,
+			pgx.NamedArgs{
+				"id":           uuid.NewString(),
+				"total_number": container.TotalContainers,
+				"timestamp":    container.Timestamp,
+			})
+		if err != nil {
+			return fmt.Errorf("could not update containers history into DB: %v", err)
+		}
+	}
+	return nil
+}
+
+func (s *RepoPostgres) GetApplicationsHistory(ctx context.Context) ([]*dao.ApplicationHistoryDAOInfo, error) {
+	selectStmt := `SELECT * FROM history WHERE history_type = 'application'`
+	rows, err := s.dbpool.Query(context.Background(), selectStmt)
+	if err != nil {
+		return nil, fmt.Errorf("could not get applications history from DB: %v", err)
+	}
+	defer rows.Close()
+
+	var apps []*dao.ApplicationHistoryDAOInfo
+	for rows.Next() {
+		app := &dao.ApplicationHistoryDAOInfo{}
+		var id string
+		err := rows.Scan(&id, nil, &app.TotalApplications, &app.Timestamp)
+		if err != nil {
+			return nil, fmt.Errorf("could not scan applications history from DB: %v", err)
+		}
+		apps = append(apps, app)
+	}
+	return apps, nil
+}
+
+func (s *RepoPostgres) GetContainersHistory(ctx context.Context) ([]*dao.ContainerHistoryDAOInfo, error) {
+	selectStmt := `SELECT * FROM history WHERE history_type = 'container'`
+	rows, err := s.dbpool.Query(ctx, selectStmt)
+	if err != nil {
+		return nil, fmt.Errorf("could not get containers history from DB: %v", err)
+	}
+	defer rows.Close()
+
+	var containers []*dao.ContainerHistoryDAOInfo
+	for rows.Next() {
+		container := &dao.ContainerHistoryDAOInfo{}
+		var id string
+		err := rows.Scan(&id, nil, &container.TotalContainers, &container.Timestamp)
+		if err != nil {
+			return nil, fmt.Errorf("could not scan contaienrs history from DB: %v", err)
+		}
+		containers = append(containers, container)
+	}
+	return containers, nil
+}

--- a/internal/repository/history.go
+++ b/internal/repository/history.go
@@ -10,11 +10,11 @@ import (
 )
 
 func (s *RepoPostgres) UpdateHistory(ctx context.Context, apps []*dao.ApplicationHistoryDAOInfo, containers []*dao.ContainerHistoryDAOInfo) error {
-	app_upsertStmt := `INSERT INTO history (id, history_type, total_number, timestamp) VALUES (@id, 'application', @total_number, @timestamp)`
-	container_upsertStmt := `INSERT INTO history (id, history_type, total_number, timestamp) VALUES (@id, 'container', @total_number, @timestamp)`
+	appSQL := `INSERT INTO history (id, history_type, total_number, timestamp) VALUES (@id, 'application', @total_number, @timestamp)`
+	containerSQL := `INSERT INTO history (id, history_type, total_number, timestamp) VALUES (@id, 'container', @total_number, @timestamp)`
 
 	for _, app := range apps {
-		_, err := s.dbpool.Exec(ctx, app_upsertStmt,
+		_, err := s.dbpool.Exec(ctx, appSQL,
 			pgx.NamedArgs{
 				"id":           uuid.NewString(),
 				"total_number": app.TotalApplications,
@@ -25,7 +25,7 @@ func (s *RepoPostgres) UpdateHistory(ctx context.Context, apps []*dao.Applicatio
 		}
 	}
 	for _, container := range containers {
-		_, err := s.dbpool.Exec(ctx, container_upsertStmt,
+		_, err := s.dbpool.Exec(ctx, containerSQL,
 			pgx.NamedArgs{
 				"id":           uuid.NewString(),
 				"total_number": container.TotalContainers,
@@ -39,8 +39,8 @@ func (s *RepoPostgres) UpdateHistory(ctx context.Context, apps []*dao.Applicatio
 }
 
 func (s *RepoPostgres) GetApplicationsHistory(ctx context.Context) ([]*dao.ApplicationHistoryDAOInfo, error) {
-	selectStmt := `SELECT * FROM history WHERE history_type = 'application'`
-	rows, err := s.dbpool.Query(ctx, selectStmt)
+	selectSQL := `SELECT * FROM history WHERE history_type = 'application'`
+	rows, err := s.dbpool.Query(ctx, selectSQL)
 	if err != nil {
 		return nil, fmt.Errorf("could not get applications history from DB: %v", err)
 	}
@@ -60,8 +60,8 @@ func (s *RepoPostgres) GetApplicationsHistory(ctx context.Context) ([]*dao.Appli
 }
 
 func (s *RepoPostgres) GetContainersHistory(ctx context.Context) ([]*dao.ContainerHistoryDAOInfo, error) {
-	selectStmt := `SELECT * FROM history WHERE history_type = 'container'`
-	rows, err := s.dbpool.Query(ctx, selectStmt)
+	selectSQL := `SELECT * FROM history WHERE history_type = 'container'`
+	rows, err := s.dbpool.Query(ctx, selectSQL)
 	if err != nil {
 		return nil, fmt.Errorf("could not get containers history from DB: %v", err)
 	}

--- a/internal/repository/history.go
+++ b/internal/repository/history.go
@@ -40,7 +40,7 @@ func (s *RepoPostgres) UpdateHistory(ctx context.Context, apps []*dao.Applicatio
 
 func (s *RepoPostgres) GetApplicationsHistory(ctx context.Context) ([]*dao.ApplicationHistoryDAOInfo, error) {
 	selectStmt := `SELECT * FROM history WHERE history_type = 'application'`
-	rows, err := s.dbpool.Query(context.Background(), selectStmt)
+	rows, err := s.dbpool.Query(ctx, selectStmt)
 	if err != nil {
 		return nil, fmt.Errorf("could not get applications history from DB: %v", err)
 	}

--- a/internal/repository/node.go
+++ b/internal/repository/node.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *RepoPostgres) UpsertNodes(ctx context.Context, nodes []*dao.NodeDAOInfo, partition string) error {
-	upsertNode := `INSERT INTO nodes (id, node_id, partition, host_name, rack_name, attributes, capacity, allocated,
+	upsertSQL := `INSERT INTO nodes (id, node_id, partition, host_name, rack_name, attributes, capacity, allocated,
 		occupied, available, utilized, allocations, schedulable, is_reserved, reservations )
 		VALUES (@id, @node_id, @partition, @host_name, @rack_name, @attributes, @capacity, @allocated,
 		@occupied, @available, @utilized, @allocations, @schedulable, @is_reserved, @reservations)
@@ -26,7 +26,7 @@ func (s *RepoPostgres) UpsertNodes(ctx context.Context, nodes []*dao.NodeDAOInfo
 		reservations = EXCLUDED.reservations`
 
 	for _, n := range nodes {
-		_, err := s.dbpool.Exec(ctx, upsertNode,
+		_, err := s.dbpool.Exec(ctx, upsertSQL,
 			pgx.NamedArgs{
 				"id":           uuid.NewString(),
 				"node_id":      n.NodeID,
@@ -72,9 +72,9 @@ func (s *RepoPostgres) InsertNodeUtilizations(ctx context.Context, u uuid.UUID, 
 }
 
 func (s *RepoPostgres) GetNodeUtilizations(ctx context.Context) ([]*dao.PartitionNodesUtilDAOInfo, error) {
-	selectStmt := `SELECT * FROM partition_nodes_util`
+	selectSQL := `SELECT * FROM partition_nodes_util`
 
-	rows, err := s.dbpool.Query(ctx, selectStmt)
+	rows, err := s.dbpool.Query(ctx, selectSQL)
 	if err != nil {
 		return nil, fmt.Errorf("could not get node utilizations from DB: %v", err)
 	}
@@ -94,11 +94,11 @@ func (s *RepoPostgres) GetNodeUtilizations(ctx context.Context) ([]*dao.Partitio
 }
 
 func (s RepoPostgres) GetNodesPerPartition(ctx context.Context, partition string) ([]*dao.NodeDAOInfo, error) {
-	selectStmt := "SELECT * FROM nodes WHERE partition = $1"
+	selectSQL := "SELECT * FROM nodes WHERE partition = $1"
 
 	nodes := []*dao.NodeDAOInfo{}
 
-	rows, err := s.dbpool.Query(ctx, selectStmt, partition)
+	rows, err := s.dbpool.Query(ctx, selectSQL, partition)
 	if err != nil {
 		return nil, fmt.Errorf("could not get nodes from DB: %v", err)
 	}

--- a/internal/repository/node.go
+++ b/internal/repository/node.go
@@ -70,6 +70,28 @@ func (s *RepoPostgres) InsertNodeUtilizations(ctx context.Context, u uuid.UUID, 
 	return nil
 }
 
+func (s *RepoPostgres) GetNodeUtilizations(ctx context.Context) ([]*dao.PartitionNodesUtilDAOInfo, error) {
+	selectStmt := `SELECT * FROM partition_nodes_util`
+
+	rows, err := s.dbpool.Query(ctx, selectStmt)
+	if err != nil {
+		return nil, fmt.Errorf("could not get node utilizations from DB: %v", err)
+	}
+	defer rows.Close()
+
+	var nodesUtil []*dao.PartitionNodesUtilDAOInfo
+	for rows.Next() {
+		nu := &dao.PartitionNodesUtilDAOInfo{}
+		var id string
+		err := rows.Scan(&id, &nu.ClusterID, &nu.Partition, &nu.NodesUtilList)
+		if err != nil {
+			return nil, fmt.Errorf("could not scan node utilizations from DB: %v", err)
+		}
+		nodesUtil = append(nodesUtil, nu)
+	}
+	return nodesUtil, nil
+}
+
 func (s RepoPostgres) GetNodesPerPartition(ctx context.Context, partition string) ([]*dao.NodeDAOInfo, error) {
 	selectStmt := "SELECT * FROM nodes WHERE partition = $1"
 

--- a/internal/repository/partitions.go
+++ b/internal/repository/partitions.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *RepoPostgres) UpsertPartitions(ctx context.Context, partitions []*dao.PartitionInfo) error {
-	upsertPartition := `INSERT INTO partitions (
+	upsertSQL := `INSERT INTO partitions (
 		id, 
 		cluster_id,
 		name, 
@@ -33,7 +33,7 @@ func (s *RepoPostgres) UpsertPartitions(ctx context.Context, partitions []*dao.P
 		state = EXCLUDED.state,
 		last_state_transition_time = EXCLUDED.last_state_transition_time`
 	for _, p := range partitions {
-		_, err := s.dbpool.Exec(ctx, upsertPartition,
+		_, err := s.dbpool.Exec(ctx, upsertSQL,
 			pgx.NamedArgs{
 				"id":                         uuid.NewString(),
 				"cluster_id":                 p.ClusterID,

--- a/internal/repository/partitions.go
+++ b/internal/repository/partitions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func (s *RepoPostgres) UpsertPartitions(partitions []*dao.PartitionInfo) error {
+func (s *RepoPostgres) UpsertPartitions(ctx context.Context, partitions []*dao.PartitionInfo) error {
 	upsertPartition := `INSERT INTO partitions (
 		id, 
 		cluster_id,
@@ -33,7 +33,7 @@ func (s *RepoPostgres) UpsertPartitions(partitions []*dao.PartitionInfo) error {
 		state = EXCLUDED.state,
 		last_state_transition_time = EXCLUDED.last_state_transition_time`
 	for _, p := range partitions {
-		_, err := s.dbpool.Exec(context.Background(), upsertPartition,
+		_, err := s.dbpool.Exec(ctx, upsertPartition,
 			pgx.NamedArgs{
 				"id":                         uuid.NewString(),
 				"cluster_id":                 p.ClusterID,
@@ -54,9 +54,9 @@ func (s *RepoPostgres) UpsertPartitions(partitions []*dao.PartitionInfo) error {
 	return nil
 }
 
-func (s *RepoPostgres) GetAllPartitions() ([]*dao.PartitionInfo, error) {
+func (s *RepoPostgres) GetAllPartitions(ctx context.Context) ([]*dao.PartitionInfo, error) {
 	var partitions []*dao.PartitionInfo
-	rows, err := s.dbpool.Query(context.Background(), "SELECT * FROM partitions")
+	rows, err := s.dbpool.Query(ctx, "SELECT * FROM partitions")
 	if err != nil {
 		return nil, fmt.Errorf("could not get partitions from DB: %v", err)
 	}

--- a/internal/repository/postgres.go
+++ b/internal/repository/postgres.go
@@ -15,18 +15,18 @@ type RepoPostgres struct {
 	dbpool *pgxpool.Pool
 }
 
-func NewECRepo(ctx context.Context, cfg *config.ECConfig) (error, *RepoPostgres) {
+func NewECRepo(ctx context.Context, cfg *config.ECConfig) (*RepoPostgres, error) {
 	poolCfg, err := pgxpool.ParseConfig(CreateConnectionString(cfg.PostgresConfig.Connection))
 	if err != nil {
-		return errors.Wrap(err, "cannot parse Postgres connection config"), nil
+		return nil, errors.Wrap(err, "cannot parse Postgres connection config")
 	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {
-		return errors.Wrap(err, "cannot create Postgres connection pool"), nil
+		return nil, errors.Wrap(err, "cannot create Postgres connection pool")
 	}
 
-	return nil, &RepoPostgres{config: cfg, dbpool: pool}
+	return &RepoPostgres{config: cfg, dbpool: pool}, nil
 }
 
 // Set up the DB for use, create tables
@@ -140,7 +140,7 @@ func (s *RepoPostgres) Setup(ctx context.Context) {
 			id UUID,
 			history_type history_type NOT NULL,
 			total_number BIGINT NOT NULL,
-			timestamp BIGINT NOT NULL
+			timestamp BIGINT NOT NULL,
 			UNIQUE (id),
 			PRIMARY KEY (id))`,
 	}

--- a/internal/repository/postgres.go
+++ b/internal/repository/postgres.go
@@ -107,6 +107,7 @@ func (s *RepoPostgres) Setup(ctx context.Context) {
 		`CREATE TABLE nodes(
 			id UUID,
 			node_id TEXT NOT NULL,
+			partition TEXT NOT NULL,
 			host_name TEXT NOT NULL,
 			rack_name TEXT,
 			attributes JSONB,

--- a/internal/repository/postgres.go
+++ b/internal/repository/postgres.go
@@ -140,7 +140,9 @@ func (s *RepoPostgres) Setup(ctx context.Context) {
 			id UUID,
 			history_type history_type NOT NULL,
 			total_number BIGINT NOT NULL,
-			timestamp BIGINT NOT NULL)`,
+			timestamp BIGINT NOT NULL
+			UNIQUE (id),
+			PRIMARY KEY (id))`,
 	}
 
 	for _, stmt := range setupStmts {

--- a/internal/repository/queue.go
+++ b/internal/repository/queue.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *RepoPostgres) UpsertQueues(ctx context.Context, queues []*dao.PartitionQueueDAOInfo) error {
-	upsertQueue := `INSERT INTO queues (
+	upsertSQL := `INSERT INTO queues (
 		id,
 		queue_name,
 		status,
@@ -51,7 +51,7 @@ func (s *RepoPostgres) UpsertQueues(ctx context.Context, queues []*dao.Partition
 		max_running_apps = EXCLUDED.max_running_apps,
 		running_apps = EXCLUDED.running_apps`
 	for _, q := range queues {
-		_, err := s.dbpool.Exec(ctx, upsertQueue,
+		_, err := s.dbpool.Exec(ctx, upsertSQL,
 			pgx.NamedArgs{
 				"id":                       uuid.NewString(),
 				"queue_name":               q.QueueName,
@@ -126,11 +126,11 @@ func (s *RepoPostgres) GetAllQueues(ctx context.Context) ([]*dao.PartitionQueueD
 }
 
 func (s RepoPostgres) GetQueuesPerPartition(ctx context.Context, parition string) ([]*dao.PartitionQueueDAOInfo, error) {
-	selectStmt := `SELECT * FROM queues WHERE partition = $1`
+	selectSQL := `SELECT * FROM queues WHERE partition = $1`
 
 	var queues []*dao.PartitionQueueDAOInfo
 
-	rows, err := s.dbpool.Query(ctx, selectStmt, parition)
+	rows, err := s.dbpool.Query(ctx, selectSQL, parition)
 	if err != nil {
 		return nil, fmt.Errorf("could not get queues from DB: %v", err)
 	}

--- a/internal/webservice/webservice.go
+++ b/internal/webservice/webservice.go
@@ -27,7 +27,6 @@ func NewWebService(addr string, storage *repository.RepoPostgres) *WebService {
 	}
 }
 
-// WISH(mo-fatah): change "get*" methods names to be "handle*"
 func (ws *WebService) Start(ctx context.Context) {
 	router := httprouter.New()
 	router.Handle("GET", PARTITIONS, func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
@@ -60,7 +59,7 @@ func (ws *WebService) Start(ctx context.Context) {
 	})
 	ws.server.Handler = router
 	go func() {
-		fmt.Println("Starting webservice...")
+		fmt.Printf("Starting webservice on %s\n", ws.server.Addr)
 		err := ws.server.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
 			fmt.Fprintf(os.Stderr, "HTTP serving error: %v\n", err)

--- a/internal/webservice/webservice.go
+++ b/internal/webservice/webservice.go
@@ -27,6 +27,7 @@ func NewWebService(addr string, storage *repository.RepoPostgres) *WebService {
 	}
 }
 
+// WISH(mo-fatah): change "get*" methods names to be "handle*"
 func (ws *WebService) Start(ctx context.Context) {
 	router := httprouter.New()
 	router.Handle("GET", PARTITIONS, func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
@@ -52,6 +53,10 @@ func (ws *WebService) Start(ctx context.Context) {
 	router.Handle("GET", CONTAINERS_HISTORY, func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		r = r.WithContext(ctx)
 		ws.getContainersHistory(w, r)
+	})
+	router.Handle("GET", NODE_UTILIZATION, func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		r = r.WithContext(ctx)
+		ws.getNodeUtilizations(w, r)
 	})
 	ws.server.Handler = router
 	go func() {
@@ -141,6 +146,17 @@ func (ws *WebService) getContainersHistory(w http.ResponseWriter, r *http.Reques
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 	err = json.NewEncoder(w).Encode(containersHistory)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (ws *WebService) getNodeUtilizations(w http.ResponseWriter, r *http.Request) {
+	nodeUtilization, err := ws.storage.GetNodeUtilizations(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	err = json.NewEncoder(w).Encode(nodeUtilization)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/internal/webservice/webservice.go
+++ b/internal/webservice/webservice.go
@@ -3,9 +3,12 @@ package webservice
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"os"
 	"richscott/yhs/internal/config"
 	"richscott/yhs/internal/repository"
+	"time"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -24,18 +27,54 @@ func NewWebService(addr string, storage *repository.RepoPostgres) *WebService {
 	}
 }
 
-func (ws *WebService) Start(ctx context.Context) error {
+func (ws *WebService) Start(ctx context.Context) {
 	router := httprouter.New()
-	router.Handle("GET", PARTITIONS, ws.getPartitions)
-	router.Handle("GET", QUEUES_PER_PARTITION, ws.getQueuesPerPartition)
-	router.Handle("GET", APPS_PER_PARTITION_PER_QUEUE, ws.getAppsPerPartitionPerQueue)
-	router.Handle("GET", NODES_PER_PARTITION, ws.getNodesPerPartition)
+	router.Handle("GET", PARTITIONS, func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		r = r.WithContext(ctx)
+		ws.getPartitions(w, r, p)
+	})
+	router.Handle("GET", QUEUES_PER_PARTITION, func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		r = r.WithContext(ctx)
+		ws.getQueuesPerPartition(w, r, p)
+	})
+	router.Handle("GET", APPS_PER_PARTITION_PER_QUEUE, func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		r = r.WithContext(ctx)
+		ws.getAppsPerPartitionPerQueue(w, r, p)
+	})
+	router.Handle("GET", NODES_PER_PARTITION, func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		r = r.WithContext(ctx)
+		ws.getNodesPerPartition(w, r, p)
+	})
+	router.Handle("GET", APPS_HISTORY, func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		r = r.WithContext(ctx)
+		ws.getAppsHistory(w, r)
+	})
+	router.Handle("GET", CONTAINERS_HISTORY, func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		r = r.WithContext(ctx)
+		ws.getContainersHistory(w, r)
+	})
 	ws.server.Handler = router
-	return ws.server.ListenAndServe()
+	go func() {
+		fmt.Println("Starting webservice...")
+		err := ws.server.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			fmt.Fprintf(os.Stderr, "HTTP serving error: %v\n", err)
+		}
+	}()
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		fmt.Println("Shutting down webservice...")
+		err := ws.server.Shutdown(shutdownCtx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "HTTP server shutdown error: %v\n", err)
+		}
+	}()
 }
 
 func (ws *WebService) getPartitions(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	partitions, err := ws.storage.GetAllPartitions()
+	partitions, err := ws.storage.GetAllPartitions(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -49,7 +88,7 @@ func (ws *WebService) getPartitions(w http.ResponseWriter, r *http.Request, _ ht
 
 func (ws *WebService) getQueuesPerPartition(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 	partition := params.ByName("partition_name")
-	queues, err := ws.storage.GetQueuesPerPartition(partition)
+	queues, err := ws.storage.GetQueuesPerPartition(r.Context(), partition)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -62,7 +101,7 @@ func (ws *WebService) getQueuesPerPartition(w http.ResponseWriter, r *http.Reque
 func (ws *WebService) getAppsPerPartitionPerQueue(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 	partition := params.ByName("partition_name")
 	queue := params.ByName("queue_name")
-	apps, err := ws.storage.GetAppsPerPartitionPerQueue(partition, queue)
+	apps, err := ws.storage.GetAppsPerPartitionPerQueue(r.Context(), partition, queue)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -74,11 +113,34 @@ func (ws *WebService) getAppsPerPartitionPerQueue(w http.ResponseWriter, r *http
 
 func (ws *WebService) getNodesPerPartition(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 	partition := params.ByName("partition_name")
-	nodes, err := ws.storage.GetNodesPerPartition(partition)
+	nodes, err := ws.storage.GetNodesPerPartition(r.Context(), partition)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 	err = json.NewEncoder(w).Encode(nodes)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (ws *WebService) getAppsHistory(w http.ResponseWriter, r *http.Request) {
+	appsHistory, err := ws.storage.GetApplicationsHistory(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	err = json.NewEncoder(w).Encode(appsHistory)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+}
+
+func (ws *WebService) getContainersHistory(w http.ResponseWriter, r *http.Request) {
+	containersHistory, err := ws.storage.GetContainersHistory(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	err = json.NewEncoder(w).Encode(containersHistory)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/internal/ykclient/client.go
+++ b/internal/ykclient/client.go
@@ -289,7 +289,7 @@ func (c *Client) loadCurrentPartitionNodes(ctx context.Context, partitionName st
 			nodes = append(nodes, &n)
 		}
 	}
-	if err := c.repo.UpsertNodes(ctx, nodes); err != nil {
+	if err := c.repo.UpsertNodes(ctx, nodes, partitionName); err != nil {
 		return nil, err
 	}
 	return nodes, nil

--- a/internal/ykclient/client.go
+++ b/internal/ykclient/client.go
@@ -2,6 +2,7 @@ package ykclient
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,8 +19,10 @@ var (
 	streamEndPt = "/ws/v1/events/stream"
 	// appHistoryEndPt       = "/ws/v1/history/apps"
 	// containerHistoryEndPt = "/ws/v1/history/containers"
-	partitionsEndPt     = "/ws/v1/partitions"
-	partitionNodesEndPt = func(partitionName string) string {
+	partitionsEndPt        = "/ws/v1/partitions"
+	appsHistoryEndPt       = "/ws/v1/history/apps"
+	containersHistoryEndPt = "/ws/v1/history/containers"
+	partitionNodesEndPt    = func(partitionName string) string {
 		return fmt.Sprintf("/ws/v1/partition/%s/nodes", partitionName)
 	}
 	queuesEndPt = func(partitionName string) string {
@@ -57,8 +60,8 @@ func NewClient(httpProto string, ykHost string, ykPort int, repo *repository.Rep
 	}
 }
 
-func (c *Client) Run() error {
-	err := c.loadUpCurrentClusterState()
+func (c *Client) Run(ctx context.Context) error {
+	err := c.loadUpCurrentClusterState(ctx)
 	if err != nil {
 		return err
 	}
@@ -69,55 +72,64 @@ func (c *Client) Run() error {
 	}
 
 	reader := bufio.NewReader(resp.Body)
-	for {
-		line, err := reader.ReadBytes('\n')
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: could not read from http stream: %v", err)
-			break
-		}
+	go func() {
+		fmt.Println("Starting YuniKorn event stream client")
+		for {
+			select {
+			case <-ctx.Done():
+				// TODO: add logging here to indicate that the client is shutting down
+				return
+			default:
+				line, err := reader.ReadBytes('\n')
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error: could not read from http stream: %v", err)
+					break
+				}
 
-		ev := si.EventRecord{}
-		err = json.Unmarshal(line, &ev)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "could not unmarshal event from stream: %v\n", err)
-			break
-		}
+				ev := si.EventRecord{}
+				err = json.Unmarshal(line, &ev)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "could not unmarshal event from stream: %v\n", err)
+					break
+				}
 
-		if ev.Type == si.EventRecord_APP {
-			fmt.Printf("Application\n")
-			fmt.Printf("---------\n")
-			fmt.Printf("Type         : %s\n", si.EventRecord_Type_name[int32(ev.Type)])
-			fmt.Printf("ObjectId     : %s\n", ev.ObjectID)
-			fmt.Printf("Message      : %s\n", ev.Message)
-			fmt.Printf("Change Type  : %s\n", ev.EventChangeType)
-			fmt.Printf("Change Detail: %s\n", ev.EventChangeDetail)
-			fmt.Printf("Reference ID:  %s\n", ev.ReferenceID)
+				if ev.Type == si.EventRecord_APP {
+					fmt.Printf("Application\n")
+					fmt.Printf("---------\n")
+					fmt.Printf("Type         : %s\n", si.EventRecord_Type_name[int32(ev.Type)])
+					fmt.Printf("ObjectId     : %s\n", ev.ObjectID)
+					fmt.Printf("Message      : %s\n", ev.Message)
+					fmt.Printf("Change Type  : %s\n", ev.EventChangeType)
+					fmt.Printf("Change Detail: %s\n", ev.EventChangeDetail)
+					fmt.Printf("Reference ID:  %s\n", ev.ReferenceID)
+				}
+			}
 		}
-	}
+	}()
 	return nil
 }
 
-func (c *Client) loadUpCurrentClusterState() error {
-	partitions, err := c.loadCurrentPartitions()
+func (c *Client) loadUpCurrentClusterState(ctx context.Context) error {
+	partitions, err := c.loadCurrentPartitions(ctx)
 	if err != nil {
 		return err
 	}
 
 	for _, part := range partitions {
-		_, err := c.loadCurrentPartitionNodes(part.Name)
+		_, err := c.loadCurrentPartitionNodes(ctx, part.Name)
 		if err != nil {
 			return err
 		}
 	}
 
-	partitionQueues, err := c.loadCurrentQueues(partitions)
+	partitionQueues, err := c.loadCurrentQueues(ctx, partitions)
 	if err != nil {
 		return err
 	}
 
 	for _, q := range partitionQueues {
 		fmt.Printf("loading applications for partition %s, queue %s\n", q.Partition, q.QueueName)
-		_, err := c.loadCurrentApplications(q.Partition, q.QueueName)
+		_, err := c.loadCurrentApplications(ctx, q.Partition, q.QueueName)
 		if err != nil {
 			return err
 		}
@@ -127,11 +139,15 @@ func (c *Client) loadUpCurrentClusterState() error {
 	if err != nil {
 		return err
 	}
+	err = c.loadClusterHistory(ctx)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
 
-func (c *Client) loadCurrentPartitions() ([]*dao.PartitionInfo, error) {
+func (c *Client) loadCurrentPartitions(ctx context.Context) ([]*dao.PartitionInfo, error) {
 	partitions := []*dao.PartitionInfo{}
 	url := c.endPointURL(partitionsEndPt)
 	resp, err := http.Get(url)
@@ -157,13 +173,13 @@ func (c *Client) loadCurrentPartitions() ([]*dao.PartitionInfo, error) {
 		}
 		partitions = append(partitions, pi...)
 	}
-	if err = c.repo.UpsertPartitions(partitions); err != nil {
+	if err = c.repo.UpsertPartitions(ctx, partitions); err != nil {
 		return nil, err
 	}
 	return partitions, nil
 }
 
-func (c *Client) loadCurrentQueues(partitions []*dao.PartitionInfo) ([]*dao.PartitionQueueDAOInfo, error) {
+func (c *Client) loadCurrentQueues(ctx context.Context, partitions []*dao.PartitionInfo) ([]*dao.PartitionQueueDAOInfo, error) {
 	queues := []*dao.PartitionQueueDAOInfo{}
 	for _, p := range partitions {
 		url := c.endPointURL(queuesEndPt(p.Name))
@@ -192,13 +208,13 @@ func (c *Client) loadCurrentQueues(partitions []*dao.PartitionInfo) ([]*dao.Part
 			queues = append(queues, &qi)
 		}
 	}
-	if err := c.repo.UpsertQueues(queues); err != nil {
+	if err := c.repo.UpsertQueues(ctx, queues); err != nil {
 		return nil, err
 	}
 	return queues, nil
 }
 
-func (c *Client) loadCurrentApplications(partitionName, queueName string) ([]*dao.ApplicationDAOInfo, error) {
+func (c *Client) loadCurrentApplications(ctx context.Context, partitionName, queueName string) ([]*dao.ApplicationDAOInfo, error) {
 	apps := []*dao.ApplicationDAOInfo{}
 	url := c.endPointURL(applicationsEndPt(partitionName, queueName))
 
@@ -238,13 +254,13 @@ func (c *Client) loadCurrentApplications(partitionName, queueName string) ([]*da
 			apps = append(apps, &a)
 		}
 	}
-	if err := c.repo.UpsertApplications(apps); err != nil {
+	if err := c.repo.UpsertApplications(ctx, apps); err != nil {
 		return nil, err
 	}
 	return apps, nil
 }
 
-func (c *Client) loadCurrentPartitionNodes(partitionName string) ([]*dao.NodeDAOInfo, error) {
+func (c *Client) loadCurrentPartitionNodes(ctx context.Context, partitionName string) ([]*dao.NodeDAOInfo, error) {
 	nodes := []*dao.NodeDAOInfo{}
 	url := c.endPointURL(partitionNodesEndPt(partitionName))
 
@@ -274,13 +290,13 @@ func (c *Client) loadCurrentPartitionNodes(partitionName string) ([]*dao.NodeDAO
 			nodes = append(nodes, &n)
 		}
 	}
-	if err := c.repo.UpsertNodes(nodes); err != nil {
+	if err := c.repo.UpsertNodes(ctx, nodes); err != nil {
 		return nil, err
 	}
 	return nodes, nil
 }
 
-func (c *Client) loadCurrentNodeUtil() (*[]dao.PartitionNodesUtilDAOInfo, error) {
+func (c *Client) loadCurrentNodeUtil(ctx context.Context) (*[]dao.PartitionNodesUtilDAOInfo, error) {
 	url := c.endPointURL(nodeUtilEndPt)
 	nus := []dao.PartitionNodesUtilDAOInfo{}
 
@@ -301,11 +317,87 @@ func (c *Client) loadCurrentNodeUtil() (*[]dao.PartitionNodesUtilDAOInfo, error)
 		return nil, fmt.Errorf("could not unmarshal node utilizations from response: %v", err)
 	}
 
-	if err := c.repo.InsertNodeUtilizations(uuid.New(), &nus); err != nil {
+	if err := c.repo.InsertNodeUtilizations(ctx, uuid.New(), &nus); err != nil {
 		return nil, err
 	}
 
 	return &nus, nil
+}
+
+func (c *Client) loadClusterHistory(ctx context.Context) error {
+	appsHistory, err := c.loadAppsHistory()
+	if err != nil {
+		return err
+	}
+	containersHistory, err := c.loadContainersHistory()
+	if err != nil {
+		return err
+	}
+	return c.repo.UpdateHistory(ctx, appsHistory, containersHistory)
+}
+
+func (c *Client) loadAppsHistory() ([]*dao.ApplicationHistoryDAOInfo, error) {
+	appsHistory := []*dao.ApplicationHistoryDAOInfo{}
+	url := c.endPointURL(appsHistoryEndPt)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("could not get applications history from %s: %v", url, err)
+	}
+	reader := bufio.NewReader(resp.Body)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("could not read applications history from response: %v", err)
+		}
+		if len(line) == 0 {
+			break
+		}
+		responseAppsHistory := []dao.ApplicationHistoryDAOInfo{}
+		err = json.Unmarshal(line, &responseAppsHistory)
+		if err != nil {
+			return nil, fmt.Errorf("could not unmarshal applications history from response: %v", err)
+		}
+
+		for _, a := range responseAppsHistory {
+			appsHistory = append(appsHistory, &a)
+		}
+	}
+	return appsHistory, nil
+}
+
+func (c *Client) loadContainersHistory() ([]*dao.ContainerHistoryDAOInfo, error) {
+	containersHistory := []*dao.ContainerHistoryDAOInfo{}
+	url := c.endPointURL(containersHistoryEndPt)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("could not get containers history from %s: %v", url, err)
+	}
+	reader := bufio.NewReader(resp.Body)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("could not read containers history from response: %v", err)
+		}
+		if len(line) == 0 {
+			break
+		}
+		responseContainersHistory := []dao.ContainerHistoryDAOInfo{}
+		err = json.Unmarshal(line, &responseContainersHistory)
+		if err != nil {
+			return nil, fmt.Errorf("could not unmarshal containers history from response: %v", err)
+		}
+
+		for _, c := range responseContainersHistory {
+			containersHistory = append(containersHistory, &c)
+		}
+	}
+	return containersHistory, nil
 }
 
 func (c *Client) endPointURL(endPt string) string {

--- a/internal/ykclient/client.go
+++ b/internal/ykclient/client.go
@@ -60,15 +60,15 @@ func NewClient(httpProto string, ykHost string, ykPort int, repo *repository.Rep
 	}
 }
 
-func (c *Client) Run(ctx context.Context) error {
+func (c *Client) Run(ctx context.Context) {
 	err := c.loadUpCurrentClusterState(ctx)
 	if err != nil {
-		return err
+		fmt.Fprintf(os.Stderr, "could not load current cluster state: %v\n", err)
 	}
 	streamURL := c.endPointURL(streamEndPt)
 	resp, err := http.Get(streamURL)
 	if err != nil {
-		return fmt.Errorf("could not request from %s: %v", streamURL, err)
+		fmt.Fprintf(os.Stderr, "could not request from %s: %v", streamURL, err)
 	}
 
 	reader := bufio.NewReader(resp.Body)
@@ -106,7 +106,6 @@ func (c *Client) Run(ctx context.Context) error {
 			}
 		}
 	}()
-	return nil
 }
 
 func (c *Client) loadUpCurrentClusterState(ctx context.Context) error {
@@ -135,7 +134,7 @@ func (c *Client) loadUpCurrentClusterState(ctx context.Context) error {
 		}
 	}
 
-	_, err = c.loadCurrentNodeUtil()
+	_, err = c.loadCurrentNodeUtil(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Add the apps history and containers history endpoints
- created an initial context and passed it around instead of `context.Background()`
- add graceful shut down in the case of os signal/s received
- add node_utilizations handlers to the webservice